### PR TITLE
Fixing step 3 generating single cells filename return error

### DIFF
--- a/macros-scripts/MicrogliaMorphology_Steps/MM_Step3_GenerateSingleCells.ijm
+++ b/macros-scripts/MicrogliaMorphology_Steps/MM_Step3_GenerateSingleCells.ijm
@@ -43,14 +43,17 @@ function cellROI(input, output, filename, min, max){
 					close(label_temp+".tif");
 				}
 			}
-			return "" ;
+			close(filename);
+			roiManager("reset");
+			return "";
 		} 
 else {
+			close(filename);
+			roiManager("reset");
 			print("A problem occured in image " +  filename + ".");
-			return(filename);
+			return filename;
 		}
-		close(filename);
-		roiManager("reset");
+		
     }
 
 


### PR DESCRIPTION
Return function was not working properly. 
Additionally, in the case of skipped files, they were not closed because the return came before closing the files. Addressing Issue #20